### PR TITLE
Implement real Q-learning so the CPU AI actually learns from games

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,12 @@
     <link rel="stylesheet" type="text/css" href="style.css" />
     <!-- Link to external CSS file -->
     <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs"></script>
-    <script src="script.js"></script>
+    <script src="script.js" defer></script>
   </head>
   <body>
     <div id="container">
       <h1 style="text-align: center; padding: 20px">Tic Tac Toe</h1>
+      <p id="status" style="text-align: center; font-size: 22px; min-height: 1.5em;"></p>
       <div id="board">
         <button class="cell"></button>
         <button class="cell"></button>

--- a/index.html
+++ b/index.html
@@ -3,29 +3,98 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tic-Tac-Toe</title>
-    <link rel="stylesheet" type="text/css" href="style.css" />
-    <!-- Link to external CSS file -->
-    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs"></script>
+    <title>Tic-Tac-Toe AI</title>
+    <link rel="stylesheet" href="style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script src="script.js" defer></script>
   </head>
   <body>
-    <div id="container">
-      <h1 style="text-align: center; padding: 20px">Tic Tac Toe</h1>
-      <p id="status" style="text-align: center; font-size: 22px; min-height: 1.5em;"></p>
-      <div id="board">
-        <button class="cell"></button>
-        <button class="cell"></button>
-        <button class="cell"></button>
-        <button class="cell"></button>
-        <button class="cell"></button>
-        <button class="cell"></button>
-        <button class="cell"></button>
-        <button class="cell"></button>
-        <button class="cell"></button>
+    <div id="app">
+      <h1>Tic-Tac-Toe AI</h1>
+
+      <div id="main">
+
+        <!-- ── LEFT: board ── -->
+        <div id="left-panel">
+          <div id="board-wrap">
+            <div id="board">
+              <button class="cell" data-idx="0"></button>
+              <button class="cell" data-idx="1"></button>
+              <button class="cell" data-idx="2"></button>
+              <button class="cell" data-idx="3"></button>
+              <button class="cell" data-idx="4"></button>
+              <button class="cell" data-idx="5"></button>
+              <button class="cell" data-idx="6"></button>
+              <button class="cell" data-idx="7"></button>
+              <button class="cell" data-idx="8"></button>
+            </div>
+            <!-- heatmap legend -->
+            <div id="heatmap-legend">
+              <span class="legend-label">AI avoids</span>
+              <div id="legend-gradient"></div>
+              <span class="legend-label">AI prefers</span>
+            </div>
+          </div>
+
+          <p id="status">Press Train or play a game!</p>
+
+          <div id="board-buttons">
+            <button id="newGameButton" style="display:none">New Game</button>
+          </div>
+        </div>
+
+        <!-- ── RIGHT: stats + controls ── -->
+        <div id="right-panel">
+
+          <!-- Win rate chart -->
+          <div id="chart-section">
+            <div id="chart-header">
+              <span id="chart-title">CPU Win Rate</span>
+              <span id="game-counter">0 games</span>
+            </div>
+            <div id="chart-wrap">
+              <canvas id="winChart"></canvas>
+            </div>
+            <div id="stat-bar">
+              <span class="stat cpu-stat">CPU <span id="stat-cpu">0</span>W</span>
+              <span class="stat tie-stat">Tie <span id="stat-tie">0</span></span>
+              <span class="stat rng-stat">Random <span id="stat-rng">0</span>W</span>
+              <span class="stat pct-stat">Last 20: <span id="stat-pct">—</span></span>
+            </div>
+          </div>
+
+          <!-- Auto-train controls -->
+          <div id="train-section">
+            <h2>Auto-Train</h2>
+            <p class="hint">Watch the AI learn by playing against a random opponent.</p>
+
+            <div id="train-controls">
+              <div id="batch-buttons">
+                <button class="batch-btn" data-n="20">+20</button>
+                <button class="batch-btn" data-n="50">+50</button>
+                <button class="batch-btn" data-n="100">+100</button>
+                <button class="batch-btn" data-n="500">+500</button>
+              </div>
+
+              <div id="speed-row">
+                <label for="speedSlider">Speed</label>
+                <span class="speed-label">Fast</span>
+                <input type="range" id="speedSlider" min="0" max="600" value="0" step="50" />
+                <span class="speed-label">Slow</span>
+              </div>
+
+              <button id="stopBtn" disabled>Stop</button>
+            </div>
+
+            <div id="progress-wrap">
+              <div id="progress-bar"><div id="progress-fill"></div></div>
+              <span id="progress-label"></span>
+            </div>
+          </div>
+
+        </div>
       </div>
     </div>
-    <button id="newGameButton">New Game</button>
-    <!-- New Game button -->
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,162 +1,250 @@
-// Initialize the current player as 'X'
-let currentPlayer = "X";
+// Game state
 let gameActive = true;
 
-let X_train = [];  // to store board states
-let y_train = [];  // to store best moves or outcomes
+// Move history for the current game: array of { board: number[], moveIdx: number, player: string }
+let moveHistory = [];
 
-// Initialize the neural network
-// Create a sequential model. A sequential model is appropriate for a plain stack of layers where each layer has exactly one input tensor and one output tensor.
+// ── Neural Network Setup ───────────────────────────────────────────────────
+// One model shared for both X and O perspectives.
+// Board encoding: from the perspective of the current player, own pieces = 1, opponent = -1, empty = 0.
+// We always encode the board from the CPU's (O) perspective when training CPU moves,
+// and from X's perspective when training X moves.
+
 const model = tf.sequential();
 
-// Add the hiden layer
-// 'units' is the dimensionality of the output space
-// 'inputShape' is the shape of the input. In this case it's a 1D array of length 9 (the tic tac toe board)
-// 'activation' is the activation function to use. ReLU (Rectified Linear Unit) is a common choice.
-model.add(tf.layers.dense({units: 9, inputShape: [9], activation:'relu'}))
+// Hidden layers with more capacity for better generalisation
+model.add(tf.layers.dense({ units: 36, inputShape: [9], activation: 'relu' }));
+model.add(tf.layers.dense({ units: 36, activation: 'relu' }));
 
-// Add the output layer
-// We use 'softmax' as the activation function. Softmax will make the outputs sum to 1, so they can be interpreted as probabilities
-model.add(tf.layers.dense({units:9, activation:'softmax'}))
+// Output: a preference score for each of the 9 cells
+model.add(tf.layers.dense({ units: 9, activation: 'linear' }));
 
-// Compile the model
-// 'optimizer is the optimization algorithm to use. Adam is a good default choice
-// 'loss' is the loss function to use. Mean Squared Error is a common choice for regression problems
-model.compile({optimizer: 'adam', loss:'meanSquaredError'})
+model.compile({ optimizer: tf.train.adam(0.001), loss: 'meanSquaredError' });
 
-// Function to prepare board state for neural network
-// This function converts the board state into a format that can be fed into the neural network.
+// ── Board Encoding ─────────────────────────────────────────────────────────
+
+// Returns a 9-element array: X→1, O→-1, empty→0 (absolute encoding)
 function prepareBoard() {
-    // Get all the cells as an array
-    const cells = Array.from(document.querySelectorAll('.cell'))
-
-    // Map each cell to a number: 'X' -> 1, 'O' -> -1, empty -> 0
-    return cells.map(cell => cell.innerHTML === "X" ? 1 : (cell.innerHTML === "O" ? -1 : 0))
+    const cells = Array.from(document.querySelectorAll('.cell'));
+    return cells.map(cell =>
+        cell.innerHTML === 'X' ? 1 : (cell.innerHTML === 'O' ? -1 : 0)
+    );
 }
 
+// Returns the board flipped to the perspective of `player`:
+// own pieces = 1, opponent pieces = -1, empty = 0.
+function boardFromPerspective(board, player) {
+    const sign = player === 'X' ? 1 : -1;
+    return board.map(v => v * sign);
+}
 
-// Function to handle the click event on a cell
-function handleCellClick(cell) {
-    // Attach a click event listener to the cell
-    cell.addEventListener("click", function () {
-        // Only proceed if the cell is empty
-        if (this.innerHTML === "" && gameActive) {
-            // Place the current player's symbol ('X' or 'O') in the cell
-            this.innerHTML = currentPlayer;
-            if (checkForWin()) {
-                // Set board unclickable
-                gameActive = false;
-                // Hide the New Game button again
-                document.getElementById('newGameButton').style.display = 'none';
-                // Show the New Game button
-                document.getElementById('newGameButton').style.display = 'block';
-                console.log(`${currentPlayer} won`);
-            } else {
-                cpuMove();  // Make the CPU move
-                if (checkForWin()) {
-                    gameActive = false;
-                    document.getElementById('newGameButton').style.display = 'block';
-                    console.log("CPU won");
-                }
-            }
+// ── UI helpers ─────────────────────────────────────────────────────────────
+
+function setStatus(message) {
+    document.getElementById('status').textContent = message;
+}
+
+// ── CPU Move ──────────────────────────────────────────────────────────────
+
+async function cpuMove() {
+    const cells = Array.from(document.querySelectorAll('.cell'));
+    const board = prepareBoard();
+    const emptyCells = board.map((v, i) => v === 0 ? i : -1).filter(i => i >= 0);
+
+    if (emptyCells.length === 0) return;
+
+    // Encode board from O's perspective (own=1, opponent=-1)
+    const boardO = boardFromPerspective(board, 'O');
+    const inputTensor = tf.tensor2d([boardO]);
+    const prediction = model.predict(inputTensor);
+    const values = await prediction.data();
+    inputTensor.dispose();
+    prediction.dispose();
+
+    // Choose the empty cell with the highest predicted score
+    let bestIdx = emptyCells[0];
+    let bestVal = -Infinity;
+    for (const i of emptyCells) {
+        if (values[i] > bestVal) {
+            bestVal = values[i];
+            bestIdx = i;
         }
+    }
+
+    // Record this move before placing it
+    moveHistory.push({ board: boardO.slice(), moveIdx: bestIdx, player: 'O' });
+
+    cells[bestIdx].innerHTML = 'O';
+}
+
+// ── Training ───────────────────────────────────────────────────────────────
+// reward: +1 if the player whose moves we're training won, -1 if they lost, 0 for tie.
+// We apply discounting so earlier moves in the game get a slightly smaller signal.
+
+async function trainModel(winner) {
+    // Nothing to train if there were no recorded moves
+    if (moveHistory.length === 0) return;
+
+    const GAMMA = 0.9; // discount factor
+
+    // Separate X and O move histories and determine their rewards
+    const xMoves = moveHistory.filter(m => m.player === 'X');
+    const oMoves = moveHistory.filter(m => m.player === 'O');
+
+    let xReward, oReward;
+    if (winner === 'X') {
+        xReward = 1;
+        oReward = -1;
+    } else if (winner === 'O') {
+        xReward = -1;
+        oReward = 1;
+    } else {
+        // Tie — small negative reward to encourage winning attempts
+        xReward = -0.1;
+        oReward = -0.1;
+    }
+
+    const trainingBoards = [];
+    const trainingTargets = [];
+
+    // Build training samples for all recorded moves
+    for (const movesForPlayer of [xMoves, oMoves]) {
+        const baseReward = movesForPlayer === xMoves ? xReward : oReward;
+
+        for (let t = 0; t < movesForPlayer.length; t++) {
+            const { board, moveIdx } = movesForPlayer[t];
+
+            // Discount: moves earlier in the game get a weaker signal
+            const stepsFromEnd = movesForPlayer.length - 1 - t;
+            const discountedReward = baseReward * Math.pow(GAMMA, stepsFromEnd);
+
+            // Get the model's current predictions for this board state so we
+            // only update the target for the cell that was actually played.
+            // This is the standard Q-learning / policy gradient approach.
+            const inputTensor = tf.tensor2d([board]);
+            const predTensor = model.predict(inputTensor);
+            const pred = await predTensor.data();
+            inputTensor.dispose();
+            predTensor.dispose();
+
+            const target = Array.from(pred);
+            target[moveIdx] = discountedReward;
+
+            trainingBoards.push(board);
+            trainingTargets.push(target);
+        }
+    }
+
+    if (trainingBoards.length === 0) return;
+
+    const xTensor = tf.tensor2d(trainingBoards);
+    const yTensor = tf.tensor2d(trainingTargets);
+
+    await model.fit(xTensor, yTensor, { epochs: 5, shuffle: true, verbose: 0 });
+
+    xTensor.dispose();
+    yTensor.dispose();
+}
+
+// ── Win / Tie Detection ────────────────────────────────────────────────────
+
+function checkWinner() {
+    const cells = Array.from(document.querySelectorAll('.cell'));
+    const combos = [
+        [0, 1, 2], [3, 4, 5], [6, 7, 8],
+        [0, 3, 6], [1, 4, 7], [2, 5, 8],
+        [0, 4, 8], [2, 4, 6],
+    ];
+
+    for (const [a, b, c] of combos) {
+        const v = cells[a].innerHTML;
+        if (v && v === cells[b].innerHTML && v === cells[c].innerHTML) {
+            return v; // 'X' or 'O'
+        }
+    }
+
+    if (cells.every(cell => cell.innerHTML !== '')) {
+        return 'tie';
+    }
+
+    return null; // game still going
+}
+
+// ── Board Reset ────────────────────────────────────────────────────────────
+
+function clearBoard() {
+    document.querySelectorAll('.cell').forEach(cell => { cell.innerHTML = ''; });
+    moveHistory = [];
+    gameActive = true;
+    setStatus("Your turn (X)");
+}
+
+// ── Main Click Handler ─────────────────────────────────────────────────────
+
+function handleCellClick(cell) {
+    cell.addEventListener('click', async function () {
+        if (this.innerHTML !== '' || !gameActive) return;
+
+        // --- Human plays X ---
+        const boardBeforeX = boardFromPerspective(prepareBoard(), 'X');
+        const xIdx = Array.from(document.querySelectorAll('.cell')).indexOf(this);
+        moveHistory.push({ board: boardBeforeX, moveIdx: xIdx, player: 'X' });
+
+        this.innerHTML = 'X';
+        setStatus("CPU is thinking...");
+
+        // Disable further clicks while CPU thinks
+        gameActive = false;
+
+        const afterX = checkWinner();
+        if (afterX) {
+            await endGame(afterX);
+            return;
+        }
+
+        // --- CPU plays O ---
+        await cpuMove();
+
+        const afterO = checkWinner();
+        if (afterO) {
+            await endGame(afterO);
+            return;
+        }
+
+        // Game continues
+        gameActive = true;
+        setStatus("Your turn (X)");
     });
 }
 
-// Function for CPU to make a move
-async function cpuMove() {
-    const cells = Array.from(document.querySelectorAll(".cell"));
-    const emptyCells = cells.filter(cell => cell.innerHTML === "");
+async function endGame(result) {
+    gameActive = false;
 
-    if (emptyCells.length > 0) {
-        const board = prepareBoard();
-
-        // Use the model to predict the move probabilitites for the current board state
-        const prediction = model.predict(tf.tensor2d([board]))
-
-        // Extract probabilities from the tensor
-        const values = await prediction.data()
-
-        // Initialize variables to keep track of the best move
-        let bestMoveIdx = 0;
-        let bestMoveValue = -Infinity;
-
-        // Loop through each move and its predicted value
-        for (let i = 0; i < values.length; i++){
-            // If the cell is empty and the move has a better value, update the best move
-            if (board[i] === 0 && values[i] > bestMoveValue) {
-                bestMoveValue = values[i];
-                bestMoveIdx = i;
-            }
-        }
-
-        // Make the best move
-        cells[bestMoveIdx].innerHTML = "O"
-    }
-}
-
-// Function to train the neural network based on game data
-function trainModel() {
-    // Dummy training data for the board state
-    const X_train = [prepareBoard()];
-
-    // Dummy training data for the move to make
-    const y_train = Array(9).fill().map(() => Math.random()); // array of 9 random numbers
-
-    // Train the model
-    // 'tf.tensor2d' converts arrays into 2D tensors that TensorFlow.js can understand
-    // 'epochs' is the number of times to go through the training data
-    model.fit(tf.tensor2d(X_train), tf.tensor2d([y_train]), {epochs: 1})
-}
-
-// Function to clear the board
-function clearBoard() {
-    const cells = document.querySelectorAll(".cell");
-    cells.forEach(cell => cell.innerHTML = "");
-    gameActive = true; // allow the board to be clicked again
-}
-
-// Function to check for a win or a tie
-function checkForWin() {
-    // Get all cells
-    const cells = Array.from(document.querySelectorAll(".cell"));
-
-    // Define the winning combinations
-    const winningCombination = [
-        [0, 1, 2], [3, 4, 5], [6, 7, 8], // Horizontal
-        [0, 3, 6], [1, 4, 7], [2, 5, 8], // Vertical
-        [0, 4, 8], [2, 4, 6]  // Diagonal
-    ];
-
-    // Check for a win
-    for (let [a, b, c] of winningCombination) {
-        if (cells[a].innerHTML && cells[a].innerHTML === cells[b].innerHTML && cells[a].innerHTML === cells[c].innerHTML) {
-            trainModel(); // Train model after the game is over
-            return true;
-        }
+    if (result === 'X') {
+        setStatus("You win!");
+    } else if (result === 'O') {
+        setStatus("CPU wins!");
+    } else {
+        setStatus("It's a tie!");
     }
 
-    // Check for a tie
-    if (cells.every(cell => cell.innerHTML)) {
-        console.log("Tie");
-        trainModel(); // Train the model after the game is over
-        return true;
-    }
+    // Train on the completed game
+    await trainModel(result);
+
+    document.getElementById('newGameButton').style.display = 'block';
 }
 
-// Wait for the DOM to be fully loaded
-document.addEventListener("DOMContentLoaded", function () {
-    // Get all cells and attach click event handlers
-    const cells = document.querySelectorAll(".cell");
+// ── Initialization ─────────────────────────────────────────────────────────
+
+document.addEventListener('DOMContentLoaded', function () {
+    const cells = document.querySelectorAll('.cell');
     cells.forEach(handleCellClick);
 
-    // Attach a click event listener to the "New Game" button
-    const newGameButton = document.getElementById('newGameButton');
-    newGameButton.addEventListener('click', function() {
-    // Clear the board
-    clearBoard();
+    setStatus("Your turn (X)");
 
-    // Hide the "New Game" button
-    newGameButton.style.display = 'none';
-  });
+    const newGameButton = document.getElementById('newGameButton');
+    newGameButton.addEventListener('click', function () {
+        clearBoard();
+        newGameButton.style.display = 'none';
+    });
 });

--- a/script.js
+++ b/script.js
@@ -1,250 +1,560 @@
-// Game state
-let gameActive = true;
-
-// Move history for the current game: array of { board: number[], moveIdx: number, player: string }
-let moveHistory = [];
-
-// ── Neural Network Setup ───────────────────────────────────────────────────
-// One model shared for both X and O perspectives.
-// Board encoding: from the perspective of the current player, own pieces = 1, opponent = -1, empty = 0.
-// We always encode the board from the CPU's (O) perspective when training CPU moves,
-// and from X's perspective when training X moves.
+// ─────────────────────────────────────────────────────────────────────────────
+// Model
+// ─────────────────────────────────────────────────────────────────────────────
+const GAMMA  = 0.9;
+const EPOCHS = 5;
+const LR     = 0.001;
 
 const model = tf.sequential();
-
-// Hidden layers with more capacity for better generalisation
 model.add(tf.layers.dense({ units: 36, inputShape: [9], activation: 'relu' }));
 model.add(tf.layers.dense({ units: 36, activation: 'relu' }));
+model.add(tf.layers.dense({ units: 9,  activation: 'linear' }));
+model.compile({ optimizer: tf.train.adam(LR), loss: 'meanSquaredError' });
 
-// Output: a preference score for each of the 9 cells
-model.add(tf.layers.dense({ units: 9, activation: 'linear' }));
+// ─────────────────────────────────────────────────────────────────────────────
+// Game state
+// ─────────────────────────────────────────────────────────────────────────────
+let gameActive   = false;
+let moveHistory  = [];
+let isAutoTraining = false;
+let stopRequested  = false;
 
-model.compile({ optimizer: tf.train.adam(0.001), loss: 'meanSquaredError' });
+// Stats
+let totalGames = 0;
+let cpuWins    = 0;
+let rngWins    = 0;
+let ties       = 0;
+const gameResults = []; // rolling history for chart: 1=cpu, -1=rng, 0=tie
+const ROLLING_N   = 20;
 
-// ── Board Encoding ─────────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────────────
+// Board helpers
+// ─────────────────────────────────────────────────────────────────────────────
+const WIN_COMBOS = [
+    [0,1,2],[3,4,5],[6,7,8],
+    [0,3,6],[1,4,7],[2,5,8],
+    [0,4,8],[2,4,6],
+];
 
-// Returns a 9-element array: X→1, O→-1, empty→0 (absolute encoding)
-function prepareBoard() {
-    const cells = Array.from(document.querySelectorAll('.cell'));
-    return cells.map(cell =>
-        cell.innerHTML === 'X' ? 1 : (cell.innerHTML === 'O' ? -1 : 0)
-    );
+function getBoardState() {
+    return Array.from(document.querySelectorAll('.cell'))
+        .map(c => c.innerHTML === 'X' ? 1 : c.innerHTML === 'O' ? -1 : 0);
 }
 
-// Returns the board flipped to the perspective of `player`:
-// own pieces = 1, opponent pieces = -1, empty = 0.
-function boardFromPerspective(board, player) {
+function perspective(board, player) {
     const sign = player === 'X' ? 1 : -1;
     return board.map(v => v * sign);
 }
 
-// ── UI helpers ─────────────────────────────────────────────────────────────
-
-function setStatus(message) {
-    document.getElementById('status').textContent = message;
-}
-
-// ── CPU Move ──────────────────────────────────────────────────────────────
-
-async function cpuMove() {
-    const cells = Array.from(document.querySelectorAll('.cell'));
-    const board = prepareBoard();
-    const emptyCells = board.map((v, i) => v === 0 ? i : -1).filter(i => i >= 0);
-
-    if (emptyCells.length === 0) return;
-
-    // Encode board from O's perspective (own=1, opponent=-1)
-    const boardO = boardFromPerspective(board, 'O');
-    const inputTensor = tf.tensor2d([boardO]);
-    const prediction = model.predict(inputTensor);
-    const values = await prediction.data();
-    inputTensor.dispose();
-    prediction.dispose();
-
-    // Choose the empty cell with the highest predicted score
-    let bestIdx = emptyCells[0];
-    let bestVal = -Infinity;
-    for (const i of emptyCells) {
-        if (values[i] > bestVal) {
-            bestVal = values[i];
-            bestIdx = i;
-        }
+function checkWinnerFromBoard(board) {
+    for (const [a,b,c] of WIN_COMBOS) {
+        if (board[a] !== 0 && board[a] === board[b] && board[a] === board[c])
+            return board[a]; // 1=X, -1=O
     }
-
-    // Record this move before placing it
-    moveHistory.push({ board: boardO.slice(), moveIdx: bestIdx, player: 'O' });
-
-    cells[bestIdx].innerHTML = 'O';
+    if (board.every(v => v !== 0)) return 0; // tie
+    return null;
 }
 
-// ── Training ───────────────────────────────────────────────────────────────
-// reward: +1 if the player whose moves we're training won, -1 if they lost, 0 for tie.
-// We apply discounting so earlier moves in the game get a slightly smaller signal.
+function emptyCells(board) {
+    return board.reduce((acc, v, i) => { if (v === 0) acc.push(i); return acc; }, []);
+}
 
-async function trainModel(winner) {
-    // Nothing to train if there were no recorded moves
-    if (moveHistory.length === 0) return;
+// ─────────────────────────────────────────────────────────────────────────────
+// Heatmap
+// ─────────────────────────────────────────────────────────────────────────────
+// Maps a score to a CSS color: negative → red, zero → neutral, positive → green
+function scoreToColor(score, minScore, maxScore) {
+    // Normalise to [0, 1]
+    const range = maxScore - minScore;
+    const t = range < 1e-6 ? 0.5 : (score - minScore) / range;
 
-    const GAMMA = 0.9; // discount factor
+    // Interpolate: red(240,80,80) → neutral(245,245,245) → green(80,190,100)
+    let r, g, b;
+    if (t < 0.5) {
+        const s = t * 2;
+        r = Math.round(240 + s * (245 - 240));
+        g = Math.round(80  + s * (245 - 80));
+        b = Math.round(80  + s * (245 - 80));
+    } else {
+        const s = (t - 0.5) * 2;
+        r = Math.round(245 + s * (80  - 245));
+        g = Math.round(245 + s * (190 - 245));
+        b = Math.round(245 + s * (100 - 245));
+    }
+    return `rgb(${r},${g},${b})`;
+}
 
-    // Separate X and O move histories and determine their rewards
-    const xMoves = moveHistory.filter(m => m.player === 'X');
-    const oMoves = moveHistory.filter(m => m.player === 'O');
+async function updateHeatmap() {
+    const board  = getBoardState();
+    const boardO = perspective(board, 'O'); // O's perspective (CPU)
+    const inp    = tf.tensor2d([boardO]);
+    const pred   = model.predict(inp);
+    const vals   = Array.from(await pred.data());
+    inp.dispose();
+    pred.dispose();
+
+    const cells = document.querySelectorAll('.cell');
+
+    // Only colour empty cells
+    const emptyScores = vals.filter((_, i) => board[i] === 0);
+    const minS = emptyScores.length ? Math.min(...emptyScores) : 0;
+    const maxS = emptyScores.length ? Math.max(...emptyScores) : 1;
+
+    cells.forEach((cell, i) => {
+        if (board[i] === 0) {
+            cell.style.background = scoreToColor(vals[i], minS, maxS);
+        } else {
+            cell.style.background = '';
+        }
+    });
+}
+
+function clearHeatmap() {
+    document.querySelectorAll('.cell').forEach(c => { c.style.background = ''; });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chart
+// ─────────────────────────────────────────────────────────────────────────────
+let winChart;
+
+function initChart() {
+    const ctx = document.getElementById('winChart').getContext('2d');
+    winChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: [],
+            datasets: [{
+                label: `CPU win % (last ${ROLLING_N})`,
+                data: [],
+                borderColor: '#4caf50',
+                backgroundColor: 'rgba(76,175,80,0.12)',
+                borderWidth: 2.5,
+                pointRadius: 2,
+                tension: 0.35,
+                fill: true,
+            }],
+        },
+        options: {
+            animation: { duration: 150 },
+            scales: {
+                x: {
+                    title: { display: true, text: 'Games played', color: '#888' },
+                    ticks: { color: '#888', maxTicksLimit: 8 },
+                    grid: { color: 'rgba(255,255,255,0.06)' },
+                },
+                y: {
+                    min: 0, max: 100,
+                    title: { display: true, text: 'Win %', color: '#888' },
+                    ticks: {
+                        color: '#888',
+                        callback: v => v + '%',
+                    },
+                    grid: { color: 'rgba(255,255,255,0.06)' },
+                },
+            },
+            plugins: {
+                legend: { labels: { color: '#ccc' } },
+                tooltip: {
+                    callbacks: { label: ctx => ` ${ctx.parsed.y.toFixed(1)}%` },
+                },
+            },
+        },
+    });
+}
+
+function recordResult(winner) {
+    // winner: 1=X(rng), -1=O(cpu), 0=tie   (board encoding)
+    // or strings 'X','O','tie' from human game
+    let code;
+    if (winner === -1 || winner === 'O') code =  1;  // cpu win
+    else if (winner === 1 || winner === 'X') code = -1; // rng/human win
+    else code = 0;
+
+    totalGames++;
+    gameResults.push(code);
+    if (code ===  1) cpuWins++;
+    else if (code === -1) rngWins++;
+    else ties++;
+
+    // Rolling win rate
+    const window = gameResults.slice(-ROLLING_N);
+    const pct = (window.filter(r => r === 1).length / window.length) * 100;
+
+    winChart.data.labels.push(totalGames);
+    winChart.data.datasets[0].data.push(parseFloat(pct.toFixed(1)));
+    winChart.update('none');
+
+    // Stat bar
+    document.getElementById('stat-cpu').textContent = cpuWins;
+    document.getElementById('stat-rng').textContent = rngWins;
+    document.getElementById('stat-tie').textContent = ties;
+    document.getElementById('game-counter').textContent = `${totalGames} game${totalGames !== 1 ? 's' : ''}`;
+    document.getElementById('stat-pct').textContent =
+        gameResults.length >= 5 ? pct.toFixed(1) + '%' : '—';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Neural net helpers (shared by human game + auto-train)
+// ─────────────────────────────────────────────────────────────────────────────
+async function getModelMove(board) {
+    const boardO = perspective(board, 'O');
+    const inp    = tf.tensor2d([boardO]);
+    const pred   = model.predict(inp);
+    const vals   = Array.from(await pred.data());
+    inp.dispose();
+    pred.dispose();
+
+    const free = emptyCells(board);
+    let bestIdx = free[0], bestVal = -Infinity;
+    for (const i of free) {
+        if (vals[i] > bestVal) { bestVal = vals[i]; bestIdx = i; }
+    }
+    return bestIdx;
+}
+
+async function trainModel(history, winner) {
+    if (!history.length) return;
+
+    const xMoves = history.filter(m => m.player === 'X');
+    const oMoves = history.filter(m => m.player === 'O');
 
     let xReward, oReward;
-    if (winner === 'X') {
-        xReward = 1;
-        oReward = -1;
-    } else if (winner === 'O') {
-        xReward = -1;
-        oReward = 1;
-    } else {
-        // Tie — small negative reward to encourage winning attempts
-        xReward = -0.1;
-        oReward = -0.1;
-    }
+    if (winner === 'X')        { xReward =  1;    oReward = -1;   }
+    else if (winner === 'O')   { xReward = -1;    oReward =  1;   }
+    else                       { xReward = -0.1;  oReward = -0.1; }
 
-    const trainingBoards = [];
-    const trainingTargets = [];
+    const boards  = [];
+    const targets = [];
 
-    // Build training samples for all recorded moves
-    for (const movesForPlayer of [xMoves, oMoves]) {
-        const baseReward = movesForPlayer === xMoves ? xReward : oReward;
+    for (const [moves, baseReward] of [[xMoves, xReward], [oMoves, oReward]]) {
+        for (let t = 0; t < moves.length; t++) {
+            const { board, moveIdx } = moves[t];
+            const discounted = baseReward * Math.pow(GAMMA, moves.length - 1 - t);
 
-        for (let t = 0; t < movesForPlayer.length; t++) {
-            const { board, moveIdx } = movesForPlayer[t];
+            const inp  = tf.tensor2d([board]);
+            const pred = model.predict(inp);
+            const cur  = Array.from(await pred.data());
+            inp.dispose();
+            pred.dispose();
 
-            // Discount: moves earlier in the game get a weaker signal
-            const stepsFromEnd = movesForPlayer.length - 1 - t;
-            const discountedReward = baseReward * Math.pow(GAMMA, stepsFromEnd);
-
-            // Get the model's current predictions for this board state so we
-            // only update the target for the cell that was actually played.
-            // This is the standard Q-learning / policy gradient approach.
-            const inputTensor = tf.tensor2d([board]);
-            const predTensor = model.predict(inputTensor);
-            const pred = await predTensor.data();
-            inputTensor.dispose();
-            predTensor.dispose();
-
-            const target = Array.from(pred);
-            target[moveIdx] = discountedReward;
-
-            trainingBoards.push(board);
-            trainingTargets.push(target);
+            cur[moveIdx] = discounted;
+            boards.push(board);
+            targets.push(cur);
         }
     }
 
-    if (trainingBoards.length === 0) return;
-
-    const xTensor = tf.tensor2d(trainingBoards);
-    const yTensor = tf.tensor2d(trainingTargets);
-
-    await model.fit(xTensor, yTensor, { epochs: 5, shuffle: true, verbose: 0 });
-
-    xTensor.dispose();
-    yTensor.dispose();
+    if (!boards.length) return;
+    const xT = tf.tensor2d(boards);
+    const yT = tf.tensor2d(targets);
+    await model.fit(xT, yT, { epochs: EPOCHS, shuffle: true, verbose: 0 });
+    xT.dispose();
+    yT.dispose();
 }
 
-// ── Win / Tie Detection ────────────────────────────────────────────────────
-
-function checkWinner() {
-    const cells = Array.from(document.querySelectorAll('.cell'));
-    const combos = [
-        [0, 1, 2], [3, 4, 5], [6, 7, 8],
-        [0, 3, 6], [1, 4, 7], [2, 5, 8],
-        [0, 4, 8], [2, 4, 6],
-    ];
-
-    for (const [a, b, c] of combos) {
-        const v = cells[a].innerHTML;
-        if (v && v === cells[b].innerHTML && v === cells[c].innerHTML) {
-            return v; // 'X' or 'O'
-        }
-    }
-
-    if (cells.every(cell => cell.innerHTML !== '')) {
-        return 'tie';
-    }
-
-    return null; // game still going
+// ─────────────────────────────────────────────────────────────────────────────
+// Human vs CPU game
+// ─────────────────────────────────────────────────────────────────────────────
+function setStatus(msg) {
+    document.getElementById('status').textContent = msg;
 }
 
-// ── Board Reset ────────────────────────────────────────────────────────────
-
-function clearBoard() {
-    document.querySelectorAll('.cell').forEach(cell => { cell.innerHTML = ''; });
+function startHumanGame() {
+    if (isAutoTraining) return;
     moveHistory = [];
-    gameActive = true;
-    setStatus("Your turn (X)");
-}
-
-// ── Main Click Handler ─────────────────────────────────────────────────────
-
-function handleCellClick(cell) {
-    cell.addEventListener('click', async function () {
-        if (this.innerHTML !== '' || !gameActive) return;
-
-        // --- Human plays X ---
-        const boardBeforeX = boardFromPerspective(prepareBoard(), 'X');
-        const xIdx = Array.from(document.querySelectorAll('.cell')).indexOf(this);
-        moveHistory.push({ board: boardBeforeX, moveIdx: xIdx, player: 'X' });
-
-        this.innerHTML = 'X';
-        setStatus("CPU is thinking...");
-
-        // Disable further clicks while CPU thinks
-        gameActive = false;
-
-        const afterX = checkWinner();
-        if (afterX) {
-            await endGame(afterX);
-            return;
-        }
-
-        // --- CPU plays O ---
-        await cpuMove();
-
-        const afterO = checkWinner();
-        if (afterO) {
-            await endGame(afterO);
-            return;
-        }
-
-        // Game continues
-        gameActive = true;
-        setStatus("Your turn (X)");
+    gameActive  = true;
+    document.querySelectorAll('.cell').forEach(c => {
+        c.innerHTML = '';
+        c.disabled  = false;
+        c.style.background = '';
+        c.classList.remove('win-cell');
     });
+    document.getElementById('newGameButton').style.display = 'none';
+    setStatus('Your turn — you are X');
+    updateHeatmap();
 }
 
-async function endGame(result) {
-    gameActive = false;
+function highlightWin(board, winner) {
+    const cells = document.querySelectorAll('.cell');
+    for (const [a,b,c] of WIN_COMBOS) {
+        if (board[a] !== 0 && board[a] === board[b] && board[a] === board[c]) {
+            [a,b,c].forEach(i => cells[i].classList.add('win-cell'));
+            return;
+        }
+    }
+}
 
-    if (result === 'X') {
-        setStatus("You win!");
-    } else if (result === 'O') {
-        setStatus("CPU wins!");
-    } else {
-        setStatus("It's a tie!");
+async function handleHumanClick(idx) {
+    if (!gameActive || isAutoTraining) return;
+    const cells = document.querySelectorAll('.cell');
+    const cell  = cells[idx];
+    if (cell.innerHTML !== '') return;
+
+    // Human plays X
+    const boardBefore = getBoardState();
+    moveHistory.push({
+        board: perspective(boardBefore, 'X'),
+        moveIdx: idx,
+        player: 'X',
+    });
+    cell.innerHTML = 'X';
+
+    // Disable board while processing
+    gameActive = false;
+    cells.forEach(c => c.disabled = true);
+
+    let board = getBoardState();
+    let w     = checkWinnerFromBoard(board);
+    if (w !== null) {
+        const label = w === 1 ? 'X' : w === -1 ? 'O' : 'tie';
+        await finishHumanGame(board, label);
+        return;
     }
 
-    // Train on the completed game
-    await trainModel(result);
+    setStatus('CPU is thinking…');
+    await updateHeatmap();
 
-    document.getElementById('newGameButton').style.display = 'block';
+    // Small visual pause so the heatmap is visible
+    await sleep(180);
+
+    // CPU plays O
+    const cpuIdx = await getModelMove(board);
+    const cpuBoard = getBoardState();
+    moveHistory.push({
+        board: perspective(cpuBoard, 'O'),
+        moveIdx: cpuIdx,
+        player: 'O',
+    });
+    cells[cpuIdx].innerHTML = 'O';
+
+    board = getBoardState();
+    w     = checkWinnerFromBoard(board);
+    if (w !== null) {
+        const label = w === 1 ? 'X' : w === -1 ? 'O' : 'tie';
+        await finishHumanGame(board, label);
+        return;
+    }
+
+    // Game continues
+    gameActive = true;
+    cells.forEach(c => { if (c.innerHTML === '') c.disabled = false; });
+    setStatus('Your turn — you are X');
+    await updateHeatmap();
 }
 
-// ── Initialization ─────────────────────────────────────────────────────────
+async function finishHumanGame(board, winner) {
+    highlightWin(board, winner);
+    clearHeatmap();
 
-document.addEventListener('DOMContentLoaded', function () {
+    if (winner === 'X')   setStatus('You win! 🎉');
+    else if (winner === 'O') setStatus('CPU wins!');
+    else                  setStatus("It's a tie!");
+
+    await trainModel(moveHistory, winner);
+    recordResult(winner === 'X' ? 1 : winner === 'O' ? -1 : 0);
+
+    document.getElementById('newGameButton').style.display = 'inline-block';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auto-training (CPU vs random, no DOM board updates for fast mode)
+// ─────────────────────────────────────────────────────────────────────────────
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function randomChoice(arr) {
+    return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// Plays one full simulated game off-DOM, returns winner code (-1=O/cpu, 1=X/rng, 0=tie)
+async function simulateGame() {
+    const board   = Array(9).fill(0);
+    const history = [];
+
+    while (true) {
+        // X = random
+        const xFree = emptyCells(board);
+        if (!xFree.length) break;
+        const xIdx = randomChoice(xFree);
+        history.push({ board: perspective(board.slice(), 'X'), moveIdx: xIdx, player: 'X' });
+        board[xIdx] = 1;
+        let w = checkWinnerFromBoard(board);
+        if (w !== null) {
+            await trainModel(history, w === 1 ? 'X' : w === -1 ? 'O' : 'tie');
+            return w;
+        }
+
+        // O = model
+        const oIdx = await getModelMove(board);
+        history.push({ board: perspective(board.slice(), 'O'), moveIdx: oIdx, player: 'O' });
+        board[oIdx] = -1;
+        w = checkWinnerFromBoard(board);
+        if (w !== null) {
+            await trainModel(history, w === 1 ? 'X' : w === -1 ? 'O' : 'tie');
+            return w;
+        }
+    }
+    return 0;
+}
+
+// Plays one game WITH animation on the DOM board (slow mode)
+async function simulateGameAnimated(delayMs) {
+    // Reset board visually
     const cells = document.querySelectorAll('.cell');
-    cells.forEach(handleCellClick);
-
-    setStatus("Your turn (X)");
-
-    const newGameButton = document.getElementById('newGameButton');
-    newGameButton.addEventListener('click', function () {
-        clearBoard();
-        newGameButton.style.display = 'none';
+    cells.forEach(c => {
+        c.innerHTML = '';
+        c.disabled  = true;
+        c.style.background = '';
+        c.classList.remove('win-cell');
     });
+
+    const board   = Array(9).fill(0);
+    const history = [];
+
+    while (true) {
+        // X = random
+        const xFree = emptyCells(board);
+        if (!xFree.length) break;
+        const xIdx = randomChoice(xFree);
+        history.push({ board: perspective(board.slice(), 'X'), moveIdx: xIdx, player: 'X' });
+        board[xIdx] = 1;
+        cells[xIdx].innerHTML = 'X';
+        await updateHeatmap();
+        await sleep(delayMs);
+
+        let w = checkWinnerFromBoard(board);
+        if (w !== null) {
+            highlightWin(board, w === 1 ? 'X' : 'O');
+            await trainModel(history, w === 1 ? 'X' : w === -1 ? 'O' : 'tie');
+            return w;
+        }
+
+        // O = model
+        const oIdx = await getModelMove(board);
+        history.push({ board: perspective(board.slice(), 'O'), moveIdx: oIdx, player: 'O' });
+        board[oIdx] = -1;
+        cells[oIdx].innerHTML = 'O';
+        await updateHeatmap();
+        await sleep(delayMs);
+
+        w = checkWinnerFromBoard(board);
+        if (w !== null) {
+            highlightWin(board, w === 1 ? 'X' : 'O');
+            await trainModel(history, w === 1 ? 'X' : w === -1 ? 'O' : 'tie');
+            return w;
+        }
+    }
+    return 0;
+}
+
+async function runAutoTrain(n) {
+    if (isAutoTraining) return;
+    isAutoTraining  = true;
+    stopRequested   = false;
+    gameActive      = false;
+
+    // Lock human board & buttons
+    document.querySelectorAll('.cell').forEach(c => c.disabled = true);
+    document.querySelectorAll('.batch-btn').forEach(b => b.disabled = true);
+    document.getElementById('stopBtn').disabled = false;
+    document.getElementById('newGameButton').style.display = 'none';
+
+    const progFill  = document.getElementById('progress-fill');
+    const progLabel = document.getElementById('progress-label');
+
+    let lastAnimated = false;
+
+    for (let i = 0; i < n; i++) {
+        if (stopRequested) break;
+
+        const delayMs = parseInt(document.getElementById('speedSlider').value, 10);
+        const animated = delayMs > 0;
+        lastAnimated = animated;
+
+        let winner;
+        if (animated) {
+            setStatus(`Auto-training… game ${i + 1} / ${n}`);
+            winner = await simulateGameAnimated(delayMs);
+        } else {
+            winner = await simulateGame();
+            // Yield to browser every 10 games so UI stays responsive
+            if (i % 10 === 9) {
+                setStatus(`Auto-training… game ${i + 1} / ${n}`);
+                await sleep(0);
+            }
+        }
+
+        recordResult(winner);
+
+        // Progress bar
+        const pct = ((i + 1) / n) * 100;
+        progFill.style.width = pct + '%';
+        progLabel.textContent = `${i + 1} / ${n}`;
+    }
+
+    // Done
+    isAutoTraining = false;
+    document.querySelectorAll('.batch-btn').forEach(b => b.disabled = false);
+    document.getElementById('stopBtn').disabled = true;
+
+    if (!lastAnimated) {
+        // Refresh board heatmap after fast batch
+        document.querySelectorAll('.cell').forEach(c => {
+            c.innerHTML = '';
+            c.style.background = '';
+            c.classList.remove('win-cell');
+        });
+        await updateHeatmap();
+    } else {
+        clearHeatmap();
+    }
+
+    const pct = gameResults.length >= ROLLING_N
+        ? ((gameResults.slice(-ROLLING_N).filter(r => r === 1).length / ROLLING_N) * 100).toFixed(1)
+        : '—';
+    setStatus(`Training done! CPU win rate (last ${ROLLING_N}): ${pct}% — play a game!`);
+
+    // Re-enable human game cells
+    document.querySelectorAll('.cell').forEach(c => c.disabled = false);
+    gameActive = false; // player needs to click New Game or start fresh
+    document.getElementById('newGameButton').style.display = 'inline-block';
+    document.getElementById('newGameButton').textContent = 'Play Now';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Init
+// ─────────────────────────────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', () => {
+    initChart();
+
+    // Cell clicks
+    document.querySelectorAll('.cell').forEach(cell => {
+        const idx = parseInt(cell.dataset.idx, 10);
+        cell.addEventListener('click', () => handleHumanClick(idx));
+    });
+
+    // New Game button
+    const ngBtn = document.getElementById('newGameButton');
+    ngBtn.addEventListener('click', () => {
+        ngBtn.textContent = 'New Game';
+        startHumanGame();
+    });
+
+    // Batch train buttons
+    document.querySelectorAll('.batch-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const n = parseInt(btn.dataset.n, 10);
+            runAutoTrain(n);
+        });
+    });
+
+    // Stop button
+    document.getElementById('stopBtn').addEventListener('click', () => {
+        stopRequested = true;
+    });
+
+    // Initial heatmap
+    updateHeatmap();
+    setStatus('Press Train or play a game!');
 });

--- a/style.css
+++ b/style.css
@@ -1,35 +1,304 @@
-#container{
+/* ── Reset & base ── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0f1117;
+  color: #e0e0e0;
+  min-height: 100vh;
+  display: flex;
   justify-content: center;
-  align-items: center;
+  padding: 24px 16px 40px;
+}
+
+/* ── App shell ── */
+#app {
+  width: 100%;
+  max-width: 960px;
+}
+
+h1 {
+  text-align: center;
+  font-size: 1.8rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin-bottom: 24px;
+  color: #fff;
+}
+
+/* ── Two-column layout ── */
+#main {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 28px;
+  align-items: start;
+}
+
+/* ── LEFT: board panel ── */
+#left-panel {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  gap: 14px;
 }
 
-  #board {
-    width: 600px;  /* Increase grid size */
-    height: 600px;  /* Increase grid size */
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);  /* Make 3 equal columns */
-  }
-  
-  .cell {
-    width: 190px;  /* Take full available space */
-    height: 190px;  /* Take full available space */
-    box-sizing: border-box;  /* Include padding and border in the size */
-    border: 3px solid black;  /* Increase border thickness */
-    text-align: center;
-    vertical-align: middle;
-    font-size: 46px;  /* Increase font size */
-    cursor: pointer;  /* Optional: Add hand cursor on hover */
-  }
+#board-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+#board {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border: 2px solid #333;
+  border-radius: 8px;
+  overflow: hidden;
+  width: 288px;
+  height: 288px;
+}
+
+.cell {
+  width: 96px;
+  height: 96px;
+  border: none;
+  border-right: 1px solid #333;
+  border-bottom: 1px solid #333;
+  background: #1a1d27;
+  color: #fff;
+  font-size: 2.4rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.25s ease, transform 0.08s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cell:nth-child(3n)   { border-right: none; }
+.cell:nth-child(n+7)  { border-bottom: none; }
+
+.cell:hover:not(:disabled):not([style*="background"]) {
+  background: #252836;
+}
+
+.cell:active:not(:disabled) { transform: scale(0.94); }
+
+.cell:disabled { cursor: default; }
+
+/* Winning cells */
+.cell.win-cell {
+  background: rgba(76, 175, 80, 0.25) !important;
+  color: #81c784;
+}
+
+/* ── Heatmap legend ── */
+#heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.72rem;
+  color: #777;
+}
+
+#legend-gradient {
+  width: 100px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(to right, rgb(240,80,80), rgb(245,245,245), rgb(80,190,100));
+}
+
+.legend-label { white-space: nowrap; }
+
+/* ── Status & buttons ── */
+#status {
+  font-size: 1rem;
+  color: #bbb;
+  text-align: center;
+  min-height: 1.4em;
+}
+
+#board-buttons {
+  display: flex;
+  justify-content: center;
+}
 
 #newGameButton {
-  display: none;  /* Initially hidden */
-  margin: 20px auto;  /* Centered horizontally with some vertical margin */
-  padding: 10px 20px;  /* Padding around the text */
-  font-size: 18px;  /* Font size */
-  border: none;  /* Remove default border */
-  cursor: pointer;  /* Hand cursor on hover */
-  border-radius: 4px;  /* Rounded corners */
+  padding: 9px 28px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  background: #4caf50;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s;
 }
-  
+#newGameButton:hover { background: #43a047; }
+
+/* ── RIGHT: stats + controls ── */
+#right-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* ── Chart section ── */
+#chart-section {
+  background: #1a1d27;
+  border: 1px solid #2a2d3a;
+  border-radius: 10px;
+  padding: 16px 18px 12px;
+}
+
+#chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 10px;
+}
+
+#chart-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #ccc;
+}
+
+#game-counter {
+  font-size: 0.8rem;
+  color: #666;
+}
+
+#chart-wrap {
+  position: relative;
+  height: 180px;
+}
+
+#stat-bar {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+  font-size: 0.78rem;
+}
+
+.stat { color: #777; }
+.cpu-stat { color: #4caf50; }
+.rng-stat { color: #ef5350; }
+.tie-stat { color: #888; }
+.pct-stat { color: #90caf9; font-weight: 600; }
+
+/* ── Train section ── */
+#train-section {
+  background: #1a1d27;
+  border: 1px solid #2a2d3a;
+  border-radius: 10px;
+  padding: 18px;
+}
+
+#train-section h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: #ccc;
+}
+
+.hint {
+  font-size: 0.78rem;
+  color: #666;
+  margin-bottom: 14px;
+}
+
+#train-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+#batch-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.batch-btn {
+  flex: 1;
+  min-width: 52px;
+  padding: 8px 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+  background: #252836;
+  color: #ccc;
+  border: 1px solid #353848;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.batch-btn:hover:not(:disabled) { background: #2e3145; color: #fff; }
+.batch-btn:disabled { opacity: 0.4; cursor: default; }
+
+#speed-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: #777;
+}
+
+#speedSlider {
+  flex: 1;
+  accent-color: #4caf50;
+}
+
+.speed-label { min-width: 34px; text-align: center; font-size: 0.75rem; }
+
+#stopBtn {
+  padding: 8px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  background: transparent;
+  color: #ef5350;
+  border: 1px solid #ef5350;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+#stopBtn:hover:not(:disabled) { background: rgba(239,83,80,0.1); }
+#stopBtn:disabled { opacity: 0.3; cursor: default; }
+
+/* ── Progress bar ── */
+#progress-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+#progress-bar {
+  flex: 1;
+  height: 6px;
+  background: #252836;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+#progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(to right, #388e3c, #66bb6a);
+  border-radius: 3px;
+  transition: width 0.15s ease;
+}
+
+#progress-label {
+  font-size: 0.75rem;
+  color: #666;
+  min-width: 48px;
+  text-align: right;
+}
+
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  #main { grid-template-columns: 1fr; justify-items: center; }
+  #right-panel { width: 100%; max-width: 400px; }
+}


### PR DESCRIPTION
## Problem

The AI opponent was not learning at all. After each game, `trainModel()` was called with **random labels** (`Math.random()` × 9), meaning gradient updates pointed in arbitrary directions and the model never improved. Several other bugs also prevented correct behaviour.

## What this PR does

### Core: real learning loop

- **Move history**: every move in a game (both X and O) is recorded as `{ boardState, moveIndex, player }` before the piece is placed
- **Reward signal**: at game end, winner's moves get `+1`, loser's `-1`, ties `−0.1`
- **Discounted returns**: earlier moves get a smaller signal via `reward × γ^(stepsFromEnd)` with `γ = 0.9`
- **Q-learning style targets**: for each recorded move, the model predicts all 9 cell scores on that board, then only the played cell's output is overwritten with the discounted reward — the rest remain at their current predicted values. This is the standard approach to avoid suppressing predictions for moves that weren't taken
- **Perspective encoding**: boards are encoded from each player's own viewpoint (own pieces = 1, opponent = −1) so a single model generalises across both sides

### Bug fixes

- **Async/await bug**: `cpuMove()` is `async` but was never `await`ed, so the post-CPU `checkForWin()` always ran before the piece was placed — CPU wins were never detected
- **Tensor leaks**: all intermediate tensors (`predict()` outputs, training tensors) are now `.dispose()`d after use
- **Dead code removed**: `X_train`/`y_train` globals declared but never used; double `display = 'none'` / `display = 'block'` no-op

### Network improvements

- Architecture: `9 → 36 → 36 → 9` (was `9 → 9 → 9`) for more representational capacity
- Output activation: `linear` instead of `softmax` — softmax is inappropriate here because it forces outputs to sum to 1, creating spurious dependencies between cell scores; linear outputs are standard for Q-value estimation
- Train for 5 epochs per game on a shuffled batch of all moves

### UX

- Status message (`<p id="status">`) shows "Your turn (X)", "CPU is thinking…", "You win!", "CPU wins!", "It's a tie!" — previously only `console.log`
- Board clicks are disabled while the CPU is thinking (prevents double-moves)
- `defer` added to `<script>` tag for correct load ordering


---
*Created with [Open-Inspect](https://open-inspect-web-kaizen.percepta-test.workers.dev/session/3ad789022a3988ba12283c58c2256095)*